### PR TITLE
Added go build command into dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM golang:onbuild
 
+RUN go build -o dnscock
+
 EXPOSE 53/udp
 
 ENTRYPOINT ["/go/src/app/dnscock"] 


### PR DESCRIPTION
In dockerfile there were no build command for dnscock.
